### PR TITLE
minor: Remove deprecated check_run_id property from ActionHandler payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octoflare",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "description": "🌤️ A framework for building GitHub Apps with Cloudflare Worker",
   "type": "module",
   "main": "dist/index.js",

--- a/src/action/types/ActionHandler.ts
+++ b/src/action/types/ActionHandler.ts
@@ -5,8 +5,5 @@ import { ActionOctokit } from './ActionOctokit.js'
 export type ActionHandler = (context: {
   octokit: ActionOctokit
   appkit: ActionOctokit
-  payload: Omit<OctoflarePayload, 'token' | 'app_token' | 'check_run_id'> & {
-    /** @deprecated Use handler return value */
-    check_run_id?: number
-  }
+  payload: Omit<OctoflarePayload, 'token' | 'app_token' | 'check_run_id'>
 }) => Promise<CloseCheckParam | void> | CloseCheckParam | void


### PR DESCRIPTION
close #127

This pull request removes the deprecated check_run_id property from the ActionHandler payload in order to improve code clarity and maintainability. The check_run_id property is no longer necessary and its removal will not affect any functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Removed the deprecated `check_run_id` property from the action handler for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->