### PR TITLE
feat: add installation ID to OctoflareInstallation type and makeInstallation function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "pnpm -r dev",

--- a/packages/create-octoflare/package.json
+++ b/packages/create-octoflare/package.json
@@ -28,7 +28,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/octoflare.git",
-    "image": "https://opengraph.githubassets.com/ba6a861c0e66784d06bd55e41c650a1ddff2d414de390e7ab61a4ae73d44da12/jill64/octoflare"
+    "image": "https://opengraph.githubassets.com/6ce9ea994fb9e7f75384307cbdc7b4bb961d592c4f202da25b14b2ed36ea3b9e/jill64/octoflare"
   },
   "scripts": {
     "build": "tsc && npx publint",

--- a/packages/create-octoflare/package.json
+++ b/packages/create-octoflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-octoflare",
-  "version": "0.26.2",
+  "version": "1.1.0",
   "description": "🌤️ A CLI for creating new Octoflare projects",
   "type": "module",
   "bin": "dist/index.js",

--- a/packages/octoflare/package.json
+++ b/packages/octoflare/package.json
@@ -58,7 +58,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jill64/octoflare.git",
-    "image": "https://opengraph.githubassets.com/ba6a861c0e66784d06bd55e41c650a1ddff2d414de390e7ab61a4ae73d44da12/jill64/octoflare"
+    "image": "https://opengraph.githubassets.com/6ce9ea994fb9e7f75384307cbdc7b4bb961d592c4f202da25b14b2ed36ea3b9e/jill64/octoflare"
   },
   "scripts": {
     "build": "tsc && npx publint",

--- a/packages/octoflare/package.json
+++ b/packages/octoflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octoflare",
-  "version": "0.26.2",
+  "version": "1.1.0",
   "description": "🌤️ A framework for building GitHub Apps with Cloudflare Worker",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/octoflare/src/types/OctoflareInstallation.ts
+++ b/packages/octoflare/src/types/OctoflareInstallation.ts
@@ -12,6 +12,7 @@ export type OctoflareInstallation<Data extends OctoflarePayloadData> = {
    * Octokit instance with installation access token.
    */
   kit: Octokit
+  id: number
   createCheckRun: (params: {
     owner: string
     repo: string

--- a/packages/octoflare/src/utils/makeInstallation.ts
+++ b/packages/octoflare/src/utils/makeInstallation.ts
@@ -214,6 +214,7 @@ export const makeInstallation = async <Data extends OctoflarePayloadData>(
 
   return {
     installation: {
+      id: installation_id,
       kit,
       createCheckRun,
       startWorkflow,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added an `id` property to the `OctoflareInstallation` type and `makeInstallation` function to provide a unique identifier for installations.
- **Version Updates**
	- Updated package versions from "1.0.0" to "1.1.0" for the main package and from "0.26.2" to "1.1.0" for the `create-octoflare` package.
- **Repository Updates**
	- Updated repository image URLs for both the main package and the `create-octoflare` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->